### PR TITLE
Isabella/error json

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1.0"
 indexmap = { version = "2", features = ["serde"] }
 anyhow = "1.0.71"
 http = "1.0.0"
+axum = "0.8.4"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ serde_json = "1.0"
 indexmap = { version = "2", features = ["serde"] }
 anyhow = "1.0.71"
 http = "1.0.0"
-axum = "0.8.4"
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -83,7 +83,7 @@ impl Operation {
             }
         }));
     }
-
+    
     pub fn add_response_success_json(&mut self, schema: Option<RefOr<Schema>>) {
         self.responses.responses.insert(Self::axum_to_local_status(axum::http::StatusCode::OK), RefOr::Item({
             let mut content = indexmap::IndexMap::new();
@@ -92,6 +92,7 @@ impl Operation {
                 ..MediaType::default()
             });
             Response {
+                description: "OK".to_string(),
                 content,
                 ..Response::default()
             }

--- a/src/operation.rs
+++ b/src/operation.rs
@@ -121,9 +121,6 @@ impl Operation {
         }));
     }
 
-    //fn axum_to_local_status(status: AxumStatusCode) -> StatusCode {
-    //StatusCode::Code(status.as_u16())
-    //}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# PR Description:
This PR adds functionality to better handle success and error responses in the OpenAPI spec generation.

# Changes made:
- Added a new helper method
```rust 
pub fn add_response_error_json(&mut self, status: StatusCode, message: String) 
``` 
This allows error responses  to be added with a status code and message
- Updated the default success response in `add_response_success_json` to include a description of **OK** instead of leaving it blank.